### PR TITLE
id取得APIを追加

### DIFF
--- a/server.deno.js
+++ b/server.deno.js
@@ -1,11 +1,26 @@
 import { serveDir } from "https://deno.land/std@0.151.0/http/file_server.ts";
+import { setCookie, getCookies } from "https://deno.land/std@0.74.0/http/mod.ts";
+
+function makeId(){
+  return crypto.randomUUID();
+}
 
 Deno.serve(async (req) => {
   const pathname = new URL(req.url).pathname;
   console.log(pathname);
 
   if (req.method === "GET" && pathname === "/welcome-message") {
-    return new Response("jigインターンへようこそ！");
+    Response("jigインターンへようこそ！");
+  }
+  if (req.method === "GET" && pathname === "/getId"){
+    return new Response(
+      "set id", {
+        status: 200,
+        headers: {
+          "set-cookie": `id=${makeId()}`
+        }
+      }
+    );
   }
 
   return serveDir(req, {

--- a/server.deno.js
+++ b/server.deno.js
@@ -1,5 +1,5 @@
 import { serveDir } from "https://deno.land/std@0.151.0/http/file_server.ts";
-import { setCookie, getCookies } from "https://deno.land/std@0.74.0/http/mod.ts";
+import { getCookies } from "https://deno.land/std@0.74.0/http/mod.ts";
 
 function makeId(){
   return crypto.randomUUID();
@@ -13,6 +13,7 @@ Deno.serve(async (req) => {
     Response("jigインターンへようこそ！");
   }
   if (req.method === "GET" && pathname === "/getId"){
+    if(getCookies(req)["id"]) return new Response("id is already set");
     return new Response(
       "set id", {
         status: 200,


### PR DESCRIPTION
## 概要
server.deno.jsにidを取得できるAPIを追加しました。

## 動作確認
- Postmanでlocalhost:8000/getIdにGETリクエストを送信して、Cookieにidが入ることを確認
- VivaldiでCookieの削除をしても正常に動作することを確認