### PR TITLE
[add] 正誤判定APIを追加

### DIFF
--- a/private/sentences.csv
+++ b/private/sentences.csv
@@ -37,7 +37,7 @@
 冷たい風が頬を撫でる,tsumetaikazegahohowonaderu
 緑の木々が揺れる音,midorinokigigayureruoto
 海辺のカフェで涼む,umibenokafedesuzumu
-アイスクリームが美味しい,aisukuriimugaoishii
+アイスクリームが美味しい,aisukuri-mugaoishii
 夏の夜風が涼しい,natsunoyokazegasuzushii
 波音が心地よく響く,namiotogakimochiyokuhibiku
 流れ星が夜空を駆ける,nagareboshigayozorawokakeru

--- a/server.deno.js
+++ b/server.deno.js
@@ -97,7 +97,7 @@ Deno.serve(async (req) => {
     }
     const id = getCookies(req)['id'];
     if (!userSentence[id][1]) {
-      makeErrorResponse('sentence is not set', '10002');
+      return makeErrorResponse('sentence is not set', '10002');
     }
     const reqeustJson = await req.json();
     const sentChar = reqeustJson['alphabet'];

--- a/server.deno.js
+++ b/server.deno.js
@@ -10,7 +10,7 @@ function makeId() {
 const themeSentencesText = await Deno.readTextFile('./private/sentences.csv');
 // 改行とカンマ区切りで2次元リスト化
 const themeSentences = themeSentencesText.split('\n').map((text) => {
-  text.replaceAll('\n', '');
+  text = text.replaceAll('\r', '');
   return text.split(',');
 });
 
@@ -45,11 +45,14 @@ function makeErrorResponse(errorMessage, errorCode) {
 const expectedTypesPerSec = 2;
 // 最後に出力したユーザーごとの文章
 const userSentence = {};
+// 1文字ごとに加点する点数
+const scorePerChar = 100;
 
 Deno.serve(async (req) => {
   const pathname = new URL(req.url).pathname;
   console.log(pathname);
 
+  // ユーザidをcookieに設定する
   if (req.method === 'GET' && pathname === '/getId') {
     if (getCookies(req)['id']) return new Response('id is already set');
     return new Response(
@@ -63,6 +66,7 @@ Deno.serve(async (req) => {
     );
   }
 
+  // cookieのidからユーザごとに文章を取得する
   if (req.method === 'GET' && pathname === '/solo/getSentence') {
     const targetSentence = getRandomThemeSentence();
     if (!getCookies(req)['id']) {
@@ -84,6 +88,36 @@ Deno.serve(async (req) => {
       },
     );
     return response;
+  }
+
+  // 1文字ごとに正誤判定を行う
+  if (req.method === 'POST' && pathname === '/solo/sendCharacter') {
+    if (!getCookies(req)['id']) {
+      return makeErrorResponse('id in cookies is not set', '10001');
+    }
+    const id = getCookies(req)['id'];
+    if (!userSentence[id][1]) {
+      makeErrorResponse('sentence is not set', '10002');
+    }
+    const reqeustJson = await req.json();
+    const sentChar = reqeustJson['alphabet'];
+    let isCorrect = false;
+    if (userSentence[id][1][0] === sentChar) { // 送られた文字と文章最初の文字が一致しているか
+      isCorrect = true;
+      userSentence[id][1] = userSentence[id][1].slice(1); // 保持していた文章の1文字目を消去
+    }
+    const isCompleted = userSentence[id][1] === ''; // 文章が空なら完了
+    return new Response(
+      JSON.stringify({
+        'isCompleted': isCompleted,
+        'isCorrect': isCorrect,
+        'score': scorePerChar,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      },
+    );
   }
 
   return serveDir(req, {

--- a/server.deno.js
+++ b/server.deno.js
@@ -46,7 +46,7 @@ const expectedTypesPerSec = 2;
 // 最後に出力したユーザーごとの文章
 const userSentence = {};
 // 1文字ごとに加点する点数
-const scorePerChar = 100;
+const SCORE_PER_CHAR = 100;
 
 Deno.serve(async (req) => {
   const pathname = new URL(req.url).pathname;
@@ -111,7 +111,7 @@ Deno.serve(async (req) => {
       JSON.stringify({
         'isCompleted': isCompleted,
         'isCorrect': isCorrect,
-        'score': scorePerChar,
+        'score': SCORE_PER_CHAR,
       }),
       {
         status: 200,

--- a/server.deno.js
+++ b/server.deno.js
@@ -42,7 +42,7 @@ function makeErrorResponse(errorMessage, errorCode) {
 }
 
 // 期待される1秒間のタイプ数
-const expectedTypesPerSec = 2;
+const EXPECTED_TYPES_PER_SEC = 2;
 // 最後に出力したユーザーごとの文章
 const userSentence = {};
 // 1文字ごとに加点する点数
@@ -79,7 +79,7 @@ Deno.serve(async (req) => {
         'sentenceJapanese': targetSentence[0],
         'sentenceAlphabet': targetSentence[1],
         'expectedTime': Math.ceil(
-          targetSentence[1].length / expectedTypesPerSec,
+          targetSentence[1].length / EXPECTED_TYPES_PER_SEC,
         ),
       }),
       {


### PR DESCRIPTION
## 概要
"/solo/getSentence"に文字情報を載せたPOSTリクエストを送ると、正誤判定結果が返答されるAPIを作成。

## 動作確認
Postmanで"/solo/getSentence"にGETを送ったのち、"/solo/sendCharacter"にPOSTを送信して動作確認。
