### PR TITLE
[add] ゲーム開始のAPIを追加

### DIFF
--- a/server.deno.js
+++ b/server.deno.js
@@ -47,6 +47,8 @@ const EXPECTED_TYPES_PER_SEC = 2;
 const SCORE_PER_CHAR = 100;
 // 1ゲームの制限時間(ms)
 const TIME_LIMIT = 60 * 1000;
+// スコアの初期値
+const INITIALIZED_SCORE = 0;
 
 // 最後に出力したユーザーごとの文章
 const userSentence = {};
@@ -82,6 +84,7 @@ Deno.serve(async (req) => {
     return new Response(
       JSON.stringify({
         'endTime': userEndTime[id],
+        'initializedScore': INITIALIZED_SCORE,
       }),
       {
         status: 200,

--- a/server.deno.js
+++ b/server.deno.js
@@ -43,10 +43,15 @@ function makeErrorResponse(errorMessage, errorCode) {
 
 // 期待される1秒間のタイプ数
 const EXPECTED_TYPES_PER_SEC = 2;
-// 最後に出力したユーザーごとの文章
-const userSentence = {};
 // 1文字ごとに加点する点数
 const SCORE_PER_CHAR = 100;
+// 1ゲームの制限時間(ms)
+const TIME_LIMIT = 60 * 1000;
+
+// 最後に出力したユーザーごとの文章
+const userSentence = {};
+// ユーザーごとのゲーム終了時間
+const userEndTime = {};
 
 Deno.serve(async (req) => {
   const pathname = new URL(req.url).pathname;
@@ -62,6 +67,25 @@ Deno.serve(async (req) => {
         headers: {
           'set-cookie': `id=${makeId()}`,
         },
+      },
+    );
+  }
+
+  // ゲームスタートと同時に初期化
+  if (req.method === 'GET' && pathname === '/solo/start') {
+    if (!getCookies(req)['id']) {
+      return makeErrorResponse('id in cookies is not set', '10001');
+    }
+    const id = getCookies(req)['id'];
+    delete userSentence[id];
+    userEndTime[id] = Date.now() + TIME_LIMIT;
+    return new Response(
+      JSON.stringify({
+        'endTime': userEndTime[id],
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
       },
     );
   }
@@ -96,7 +120,7 @@ Deno.serve(async (req) => {
       return makeErrorResponse('id in cookies is not set', '10001');
     }
     const id = getCookies(req)['id'];
-    if (!userSentence[id][1]) {
+    if (!userSentence[id] || !userSentence[id][1]) {
       return makeErrorResponse('sentence is not set', '10002');
     }
     const reqeustJson = await req.json();


### PR DESCRIPTION
## 概要
ゲーム開始のAPIを追加

## 動作確認
Postmanで"/solo/start"にGETを送信。Cookieにidがない場合にはエラーレスポンスが返ることを確認。