### PR TITLE
[fix] サーバーからの得点を追加分から現在の得点に変更

### DIFF
--- a/public/css/solo.css
+++ b/public/css/solo.css
@@ -76,6 +76,16 @@
   width: 25vw;
 }
 
+#gameFooter {
+  display: flex;
+  flex-direction: row;
+  width: 80%;
+  max-width: 1200px;
+  color: white;
+  font-size: 2.4vw;
+  align-items : center;
+}
+
 meter::-webkit-meter-bar {
   background: #202020;
 }

--- a/public/js/soloScore.js
+++ b/public/js/soloScore.js
@@ -3,14 +3,14 @@ function initializeScore(initializedScore){
 	const score = document.getElementById('score');
 	score.textContent = initializedScore;
 	const scorePanel = document.getElementById('scorePanel');
-	scorePanel.style.display = block;
+	scorePanel.style.display = 'block';
 }
 
 /**
  * 得点を追加する関数
- * @param {number} addScore 追加する特典 
+ * @param {number} core 追加する特典 
  */
-function updateScore(addScore){
+function updateScore(score){
 	const score = document.getElementById('score');
-	score.textContent = parseInt(score.textContent) + addScore;
+	score.textContent = score;
 }

--- a/public/js/soloScore.js
+++ b/public/js/soloScore.js
@@ -8,7 +8,7 @@ function initializeScore(initializedScore){
 
 /**
  * 得点を追加する関数
- * @param {number} core 追加する特典 
+ * @param {number} score 追加する特典 
  */
 function updateScore(score){
 	const score = document.getElementById('score');

--- a/public/solo.html
+++ b/public/solo.html
@@ -22,6 +22,7 @@
 	<script src="js/particles.js" defer></script>
 	<script src="js/fireworkCanvas.js" defer></script>
 	<script src="js/errorHnadle.js" defer></script>
+	<script src="js/soloScore.js" defer></script>
 
 
 


### PR DESCRIPTION
## 概要
ファイル名の修正
game画面の点数と入力する文字が横になるようにCSSの修正
サーバからの得点が追加分から、現在の得点になることに対応

<!-- このPRの目的と概要を完結に説明してください -->

## 動作確認

```
/**
 * meterの初期設定
 * @param {number} time  設定する秒
 */
function setMeter(time) {
	const meter = document.getElementById('meter');
	if (meter) {
		meter.style.display = 'block';
		meter.value = 1000;
		meter.time = time;
	}
}

/**
 * タイマー更新
 */
function startMeter() {
	const meter = document.getElementById('meter');
	// 1/100秒おきに実行
	setInterval(() => {
		meter.value -= 10 / meter.time;
	}, 10);
}

function penalty(time) {
	const meter = document.getElementById('meter');
	meter.value -= 10 / meter.time * PENALTY_TIME;
}



/**
 * 文章、想定入力時間を取得し、入力する文字に設定する。
 * meterの初期化もする。
 */
async function fetchSentenceAndRefreshMeter() {
	// メーターを設定
	setMeter(10);
	startMeter();

	//  文章を設定
	document.getElementById('notEntered').textContent =
		"fuuringayureruoto";
	document.getElementById('japanese').textContent =
		"風鈴が揺れる音";

}

fetchSentenceAndRefreshMeter();



/** 指定された値に、得点を初期化して、表示 */
function initializeScore(initializedScore){
	const score = document.getElementById('score');
	score.textContent = initializedScore;
	const scorePanel = document.getElementById('scorePanel');
	scorePanel.style.display = 'block';
}

initializeScore(0);
```
<!-- どのような方法で動作確認したか説明してください -->

## DenoDeployのURL
https://dash.deno.com/projects/kaito-real-2024-d-43
<!-- このブランチを指定したDenoDeployのURLを貼り付けてください -->