### PR TITLE
[update] 結果取得のレスポンスに合計ミスタイプ数を追加

### DIFF
--- a/model/UserGame.js
+++ b/model/UserGame.js
@@ -183,6 +183,13 @@ class UserGame {
     return this.totalSentenceCount;
   }
   /**
+   * このゲームにおける合計ミスタイプ数
+   * @returns {Number}
+   */
+  calcTotalMissType() {
+    return this.totalTypeCount - this.totalCorrectTypeCount;
+  }
+  /**
    * 秒間のタイプ数を計算
    * @returns {Number} 小数は丸めない
    */

--- a/server.deno.js
+++ b/server.deno.js
@@ -161,6 +161,7 @@ Deno.serve(async (req) => {
       'fireworkCount': userGames[id].calcTotalFireworks(),
       'typesPerSecond': userGames[id].calcTypesPerSecond(),
       'typeCount': userGames[id].getTotalCorrectTypeCount(),
+      'typeMissCount': userGames[id].calcTotalMissType(),
     });
   }
 


### PR DESCRIPTION
## 概要
"/solo/getResult"のGETリクエストのレスポンスに、合計ミスタイプ数を表す"typeMissCount"を追加。

## 動作確認
Postmanで以下を確認
- ゲーム中にミスタイプを数回しておく
- ある程度時間がたったら"/solo/getResult"にGETリクエストを送る
- 返答されたtypeMissCountがミスタイプ数と一致するか確認する
