### PR TITLE
[update] 結果画面にミスタイプ数の表示を追加

### DIFF
--- a/public/js/soloResult.js
+++ b/public/js/soloResult.js
@@ -39,6 +39,10 @@ onload = async (event) => {
   const typeCountResult = document.querySelector('#typeCount');
   typeCountResult.innerHTML = `${responseObj['typeCount']}`;
 
+  //ミスタイプ数の表示
+  const typeMissCountResult = document.querySelector('#typeMissCount');
+  typeMissCountResult.innerHTML = `${responseObj['typeMissCount']}`;
+
   document.getElementById('resultContents').style.visibility = 'visible';
 };
 

--- a/public/soloResult.html
+++ b/public/soloResult.html
@@ -31,11 +31,13 @@
                             <p>大花火数: </p>
                             <p>秒間タイプ数: </p>
                             <p>正解タイプ数: </p>
+                            <p>ミスタイプ数: </p>
                         </div>
                         <div id="detailScore">
                             <p id="fireworkCount"></p>
                             <p id="typesPerSecond"></p>
                             <p id="typeCount"></p>
+                            <p id="typeMissCount"></p>
                         </div>
                     </div>
                     <div id="buttonResult">


### PR DESCRIPTION
## 概要
結果画面にミスタイプ数の表示を追加しました。

## 動作確認
![image](https://github.com/user-attachments/assets/58f6b052-7c73-4e20-91fa-19b9469c6c32)

## DenoDeployのURL
https://jigintern-2024-real-d-s4q556x95vzr.deno.dev/soloResult.html