### PR TITLE
[add] startとgetSentenceのレスポンスに読み仮名を追加

### DIFF
--- a/model/UserGame.js
+++ b/model/UserGame.js
@@ -138,11 +138,25 @@ class UserGame {
     return this.sentenceNowJapanese;
   }
   /**
-   * 現在の文章の読み仮名を取得
+   * 現在の状態に関わらずに読み仮名を取得
    * @returns {String}
    */
   getNowYomigana() {
     return this.sentenceNowTypingText.text;
+  }
+  /**
+   * 現在の残り読み仮名を取得
+   * @returns {String}
+   */
+  getRemainingYomigana() {
+    return this.sentenceNowTypingText.remainingText;
+  }
+  /**
+   * 現在の完了済み読み仮名を取得
+   * @returns {String}
+   */
+  getCompletedYomigana() {
+    return this.sentenceNowTypingText.completedText;
   }
   /**
    * 現在の状態に関わらずにタイプ文字を取得

--- a/model/UserGame.js
+++ b/model/UserGame.js
@@ -138,6 +138,13 @@ class UserGame {
     return this.sentenceNowJapanese;
   }
   /**
+   * 現在の文章の読み仮名を取得
+   * @returns {String}
+   */
+  getNowYomigana() {
+    return this.sentenceNowTypingText.text;
+  }
+  /**
    * 現在の状態に関わらずにタイプ文字を取得
    * @returns {String}
    */

--- a/server.deno.js
+++ b/server.deno.js
@@ -137,6 +137,8 @@ Deno.serve(async (req) => {
       'fireworkSize': userGames[id].calcFireworkSize(),
       'enteredChars': userGames[id].getCompletedRoman(),
       'notEnteredChars': userGames[id].getRemainingRoman(),
+      'enteredYomigana': userGames[id].getCompletedYomigana(),
+      'notEnteredYomigana': userGames[id].getRemainingYomigana(),
     });
     // 前回と違う文章が出るまで再抽選
     if (userGames[id].isCompleted()) {

--- a/server.deno.js
+++ b/server.deno.js
@@ -94,6 +94,7 @@ Deno.serve(async (req) => {
       'sentenceJapanese': userGames[id].getNowJapanese(),
       'sentenceAlphabet': userGames[id].getCompletedRoman() +
         userGames[id].getRemainingRoman(),
+      'sentenceKana': userGames[id].getNowYomigana(),
       'expectedTime': userGames[id].calcExpectedTime(),
     });
   }
@@ -111,6 +112,7 @@ Deno.serve(async (req) => {
       'sentenceJapanese': userGames[id].getNowJapanese(),
       'sentenceAlphabet': userGames[id].getCompletedRoman() +
         userGames[id].getRemainingRoman(),
+      'sentenceKana': userGames[id].getNowYomigana(),
       'expectedTime': userGames[id].calcExpectedTime(),
     });
   }


### PR DESCRIPTION
## 概要
ゲーム画面での表示用に読み仮名をレスポンスに追加
clientがこのブランチにマージしたら、mainにマージします。

## 動作確認
Postmanで以下を確認
- /solo/startにGETリクエストを送り、sentenceKanaが返っていることを確認
- /solo/getSentenceにGETリクエストを送り、sentenceKanaが返っていることを確認